### PR TITLE
CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0...3.28)
+
+project(NoodleScript)
+
+file(GLOB_RECURSE SRCS src/*.cpp)
+
+add_executable(NoodleScript ${SRCS})


### PR DESCRIPTION
Simple [CMake](https://cmake.org/) configuration to build the executable. 

Untested non-Windows but this should allow to build/run the executable on most OSs, apart for the very small Windows specific code (aka `system("cls")`). 

Note that building in Release mode does not work.